### PR TITLE
Add richDescription to plan

### DIFF
--- a/Library/Rebilly/RebillyPlan.cs
+++ b/Library/Rebilly/RebillyPlan.cs
@@ -32,6 +32,10 @@ namespace Rebilly
         /// string description
         /// </summary>
         public string description = null;
+		/// <summary>
+        /// string richDescription
+        /// </summary>
+        public string richDescription = null;
         /// <summary>
         /// string recurringAmount
         /// </summary>


### PR DESCRIPTION
To reflect the addition of `richDescription` to plans in the Rebilly API. This field supports HTML content to help merchants display rich content related to a plan via the layout or plan API resource.
